### PR TITLE
Correct typo

### DIFF
--- a/blinky/config/rpi3.exs
+++ b/blinky/config/rpi3.exs
@@ -1,4 +1,4 @@
-# Configuration for the Raspberry Pi 2 Model B (target rpi2)
+# Configuration for the Raspberry Pi 3 (target rpi3)
 use Mix.Config
 
 config :nerves_io_led, names: [ red: "led0", green: "led1" ]


### PR DESCRIPTION
Fixes a copy'n'paste error in the rpi3 config file.