### PR TITLE
Correct typo in :nerves_leds application

### DIFF
--- a/blinky/mix.exs
+++ b/blinky/mix.exs
@@ -17,7 +17,7 @@ defmodule Blinky.Mixfile do
   end
 
   def application do
-    [applications: [:nerves, :logger, :nerves_nerves_leds], mod: {Blinky, []}]
+    [applications: [:nerves, :logger, :nerves_leds], mod: {Blinky, []}]
   end
 
   defp deps do


### PR DESCRIPTION
This appears to be a typo. My project wouldn't build until I made this correction.