### PR TITLE
RPi3 no longer supports controlling the PWR LED.

### DIFF
--- a/blinky/config/rpi3.exs
+++ b/blinky/config/rpi3.exs
@@ -1,4 +1,5 @@
 # Configuration for the Raspberry Pi 3 (target rpi3)
 use Mix.Config
 
-config :nerves_leds, names: [ red: "led0", green: "led1" ]
+config :blinky, led_list: [ :green ]
+config :nerves_leds, names: [ green: "led0" ]


### PR DESCRIPTION
Only `/sys/class/leds/led0` exists on the Raspberry Pi 3 and it controls the green LED. It seems access was removed to accommodate the new wifi/BT capabilities.

https://github.com/raspberrypi/linux/issues/1332
http://raspberrypi.stackexchange.com/questions/44168/how-can-i-control-the-red-led-again