### PR TITLE
Remove redundant lines about `build_embedded` and `start_permanent`.

### DIFF
--- a/blinky/mix.exs
+++ b/blinky/mix.exs
@@ -13,8 +13,6 @@ defmodule Blinky.Mixfile do
      target: @target,
      deps_path: "deps/#{@target}",
      build_path: "_build/#{@target}",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
      aliases: aliases(),
      deps: deps() ++ system(@target)]
   end

--- a/hello_network/mix.exs
+++ b/hello_network/mix.exs
@@ -13,8 +13,6 @@ defmodule HelloNetwork.Mixfile do
      target: @target,
      deps_path: "deps/#{@target}",
      build_path: "_build/#{@target}",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
      aliases: aliases(),
      deps: deps() ++ system(@target)]
   end

--- a/hello_wifi/mix.exs
+++ b/hello_wifi/mix.exs
@@ -13,8 +13,6 @@ defmodule HelloWifi.Mixfile do
      target: @target,
      deps_path: "deps/#{@target}",
      build_path: "_build/#{@target}",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
      aliases: aliases(),
      deps: deps() ++ system(@target)]
   end


### PR DESCRIPTION
Introduced in 03592b9.