### PR TITLE
Improve the Blinky example for the RPi3

### DIFF
--- a/blinky/lib/blinky.ex
+++ b/blinky/lib/blinky.ex
@@ -7,6 +7,9 @@ defmodule Blinky do
   directory (see config.exs).   See README.md for build instructions.
   """
 
+  @on_duration  200 # ms
+  @off_duration 200 # ms
+
   alias Nerves.Leds
   require Logger
 
@@ -25,10 +28,11 @@ defmodule Blinky do
 
   # given an led key, turn it on for 100ms then back off
   defp blink(led_key) do
-  #    Logger.debug "blinking led #{inspect led_key}"
+    #Logger.debug "blinking led #{inspect led_key}"
     Leds.set [{led_key, true}]
-    :timer.sleep 100
+    :timer.sleep @on_duration
     Leds.set [{led_key, false}]
+    :timer.sleep @off_duration
   end
 
 end


### PR DESCRIPTION
Running the Blinky example on my Raspberry Pi 3, I was initially a tad underwhelmed. See the [10-second recording](https://imgur.com/e7jhYnn) of what the blinking looks like. I imagine this isn't the intended effect.

I believe the problem is that if you only have one LED, as on the RPi3, the `Blinky.blink_list_forever` loop essentially turns into the following:

    Leds.set [{:green, true}]
    :timer.sleep 100
    Leds.set [{:green, false}]
    Leds.set [{:green, true}]
    :timer.sleep 100
    Leds.set [{:green, false}]
    Leds.set [{:green, true}]
    :timer.sleep 100
    Leds.set [{:green, false}]
    ...

That is, without the implicit delay introduced by also controlling a second LED as on other RPi boards, the one and only LED effectively never gets powered off, since there isn't a `:timer.sleep` between turning it off and back on.

This pull request remedies that and makes the blinking more readily discernible and visually appealing, as per this [10-second recording](https://imgur.com/4EDQnHD) with the patch applied.