### PR TITLE
Add a HelloNetwork.test_dns function

### DIFF
--- a/hello_network/lib/hello_network.ex
+++ b/hello_network/lib/hello_network.ex
@@ -23,8 +23,8 @@ defmodule HelloNetwork do
     {:ok, _} = SSDPServer.publish usn, st
   end
 
-  @doc "Attempts to perform a DNS lookup of nerves-project.org."
-  def test_dns do
-    :inet_res.lookup('nerves-project.org', :in, :a)
+  @doc "Attempts to perform a DNS lookup to test connectivity."
+  def test_dns(hostname \\ 'nerves-project.org') do
+    :inet_res.gethostbyname(hostname)
   end
 end

--- a/hello_network/lib/hello_network.ex
+++ b/hello_network/lib/hello_network.ex
@@ -23,4 +23,8 @@ defmodule HelloNetwork do
     {:ok, _} = SSDPServer.publish usn, st
   end
 
+  @doc "Attempts to perform a DNS lookup of nerves-project.org."
+  def test_dns do
+    :inet_res.lookup('nerves-project.org', :in, :a)
+  end
 end


### PR DESCRIPTION
This pull request simply adds a trivial one-line `HelloNetwork.test_dns` function that the user can call in the IEx console to check that the Nerves host indeed has successfully established network connectivity.

The expected output when DNS resolution is available is something like this:

    iex(1)> HelloNetwork.test_dns
    {:ok,
     {:hostent, 'nerves-project.org', [], :inet, 4,
      [{192, 30, 252, 154}, {192, 30, 252, 153}]}}
