### PR TITLE
Add squashfs to the list of OSX dependencies to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ On OS X:
 ```
 brew update
 brew upgrade elixir   ## v1.2.4, BUT NOT HEAD!!
-brew install coreutils fwup
+brew install coreutils fwup squashfs
 ```
 
 On All Platforms:


### PR DESCRIPTION
Just a small addition that wasn't listed in the README.md

Without it you get an error 

```➜  blinky git:(master) ✗ mix firmware.burn
** (Mix) Squash FS Tools are required to be installed on your system.
Please see https://hexdocs.pm/nerves/installation.html#host-specific-tools
for installation instructions```