### PR TITLE
Add an alternative version for blinky

### DIFF
--- a/configurable_blinky/README.md
+++ b/configurable_blinky/README.md
@@ -1,0 +1,14 @@
+# ConfigurableBlinky
+
+To start your Nerves app:
+
+  * Install dependencies with `mix deps.get`
+  * Create firmware with `mix firmware`
+  * Burn to an SD card with `mix firmware.burn`
+
+## Learn more
+
+  * Official docs: https://hexdocs.pm/nerves/getting-started.html
+  * Official website: http://www.nerves-project.org/
+  * Discussion Slack elixir-lang #nerves ([Invite](https://elixir-slackin.herokuapp.com/))
+  * Source: https://github.com/nerves-project/nerves

--- a/configurable_blinky/config/alix.exs
+++ b/configurable_blinky/config/alix.exs
@@ -1,0 +1,10 @@
+# configuration for PC Engines Alix 2d/3d series (target alix)
+use Mix.Config
+
+config :blinky, led_list: [ :led1, :led2, :led3 ]
+
+config :nerves_leds, names: [
+  led1: "alix:1",
+  led2: "alix:2",
+  led3: "alix:3"
+]

--- a/configurable_blinky/config/bbb.exs
+++ b/configurable_blinky/config/bbb.exs
@@ -1,0 +1,11 @@
+# configuration for Beaglebone Black (target bbb)
+use Mix.Config
+
+config :blinky, led_list: [ :led0, :led1, :led2, :led3 ]
+
+config :nerves_leds, names: [
+  led0: "beaglebone:green:usr0",
+  led1: "beaglebone:green:usr1",
+  led2: "beaglebone:green:usr2",
+  led3: "beaglebone:green:usr3"
+]

--- a/configurable_blinky/config/config.exs
+++ b/configurable_blinky/config/config.exs
@@ -1,0 +1,15 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+#
+# This configuration file is loaded before any dependency and
+# is restricted to this project.
+use Mix.Config
+
+# Import target specific config. This must remain at the bottom
+# of this file so it overrides the configuration defined above.
+# Uncomment to use target specific configurations
+
+config :configurable_blinky, led_list: [ :red, :green ]
+config :nerves_leds, names: [ red: "led0", green: "led1" ]
+
+import_config "#{Mix.Project.config[:target]}.exs"

--- a/configurable_blinky/config/ev3.exs
+++ b/configurable_blinky/config/ev3.exs
@@ -1,0 +1,11 @@
+# Configuration for the Lego Mindstorms EV3 brick (target ev3)
+use Mix.Config
+
+config :blinky, led_list: [ :led0, :led1, :led2, :led3 ]
+
+config :nerves_leds, names: [
+  led0: "ev3:left:green:ev3dev",
+  led1: "ev3:right:green:ev3dev",
+  led2: "ev3:left:red:ev3dev",
+  led3: "ev3:right:red:ev3dev"
+]

--- a/configurable_blinky/config/rpi.exs
+++ b/configurable_blinky/config/rpi.exs
@@ -1,0 +1,4 @@
+# Configuration for the Raspberry Pi A+ / B+ / B / Zero (target rpi)
+use Mix.Config
+
+config :nerves_leds, names: [ red: "led0", green: "led1" ]

--- a/configurable_blinky/config/rpi2.exs
+++ b/configurable_blinky/config/rpi2.exs
@@ -1,0 +1,4 @@
+# Configuration for the Raspberry Pi 2 Model B (target rpi2)
+use Mix.Config
+
+config :nerves_leds, names: [ red: "led0", green: "led1" ]

--- a/configurable_blinky/config/rpi3.exs
+++ b/configurable_blinky/config/rpi3.exs
@@ -1,0 +1,5 @@
+# Configuration for the Raspberry Pi 3 (target rpi3)
+use Mix.Config
+
+config :blinky, led_list: [ :green ]
+config :nerves_leds, names: [ green: "led0" ]

--- a/configurable_blinky/lib/configurable_blinky.ex
+++ b/configurable_blinky/lib/configurable_blinky.ex
@@ -1,0 +1,132 @@
+defmodule ConfigurableBlinky do
+  use Application
+
+  @moduledoc """
+  This is the main module. It is composed of two submodules: `BlinkConfigWorker` and `BlinkWorker`.
+  """
+
+  # Initial duration of the on and off signals
+  @init_on_duration 100
+  @init_off_duration 100
+
+  defmodule BlinkConfigWorker do
+    use GenServer
+
+    require Logger
+
+    @moduledoc """
+    This module contains the code used to create a process for holding the
+    configuration of the blinking. The configuration comprises of:
+
+    * the time during which the light is on, in ms,
+    * the time during which the light is off, in ms,
+    * and whether or not the blinking process is on.
+
+    The process responsible for blinking will query this process by
+    issuing a `:get_durations` call. The process can be halted with
+    a `:stop` call, and restarted with a `:start` call.
+    """
+
+    def start_link(state, opts \\ []) do
+      Logger.debug "Initial state is #{inspect state}"
+      GenServer.start_link(__MODULE__, state, opts)
+       {:ok, self}
+    end
+
+    def handle_call(:get_durations, _from, context) do
+      #Logger.debug "Getting durations #{inspect context}"
+      {on, off, _running} = context
+      {:reply, {on, off}, context}
+    end
+
+    @doc """
+    Return `true` if the blinking process is running.
+    """
+    def handle_call(:is_running, _from, context) do
+      {:reply, elem(context, 2), context}
+    end
+
+    @doc """
+    Change the time during which the light is off.
+    """
+    def handle_cast({:set_off_duration, duration}, context) do
+      {old_on_duration, _old_off_duration, running} = context
+      {:noreply, {old_on_duration, duration, running}}
+    end
+
+    @doc """
+    Change the time during which the light is on.
+    """
+    def handle_cast({:set_on_duration, duration}, context) do
+      {_old_on_duration, old_off_duration, running} = context
+      {:noreply, {duration, old_off_duration, running}}
+    end
+
+    def handle_cast(:stop, context) do
+      {on, off, _old_running} = context
+      {:noreply, {on, off, false} }
+    end
+
+    def handle_cast(:start, context) do
+      {on, off, _old_running} = context
+      {:noreply, {on, off, true} }
+    end
+  end
+
+  defmodule BlinkWorker do
+    use GenServer
+
+    @moduledoc """
+    This module contains the code that is turning the leds on and
+    off. It gets its timing from the configuration process.
+    """
+
+    alias Nerves.Leds
+
+    def start_link(state, opts \\ []) do
+      GenServer.start_link(__MODULE__, state, opts)
+      led_list = Application.get_env(:configurable_blinky, :led_list)
+      spawn fn -> blink_list(led_list) end
+      {:ok, self}
+    end
+
+    defp blink_list(led_list) do
+      Enum.each(led_list, &blink(&1))
+      blink_list(led_list) #unless self.stopped
+    end
+
+    @doc """
+    Actual blinking function. See the `blinky` example.
+    """
+    defp blink(led_key) do
+      running = GenServer.call(BlinkConfig, :is_running)
+      if running do
+        {on_duration, off_duration} = GenServer.call(BlinkConfig, :get_durations)
+        Leds.set [{led_key, true}]
+        :timer.sleep on_duration
+        Leds.set [{led_key, false}]
+        :timer.sleep off_duration
+      end
+    end
+  end
+
+  @doc """
+  start of the application, create a configuration process, and a
+  process controlling the blinking.
+  """
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    # Define workers and child supervisors to be supervised
+    children = [
+      worker(ConfigurableBlinky.BlinkConfigWorker, [{@init_on_duration, @init_off_duration, true}, [name: BlinkConfig]]),
+      worker(ConfigurableBlinky.BlinkWorker, [[name: Blinker]]),
+    ]
+
+    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: ConfigurableBlinky.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+end

--- a/configurable_blinky/mix.exs
+++ b/configurable_blinky/mix.exs
@@ -1,0 +1,41 @@
+defmodule ConfigurableBlinky.Mixfile do
+  use Mix.Project
+
+  @target System.get_env("NERVES_TARGET") || "rpi3"
+
+  def project do
+    [app: :configurable_blinky,
+     version: "0.0.1",
+     target: @target,
+     archives: [nerves_bootstrap: "~> 0.1.4"],
+     deps_path: "deps/#{@target}",
+     build_path: "_build/#{@target}",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     aliases: aliases,
+     deps: deps ++ system(@target)]
+  end
+
+  # Configuration for the OTP application.
+  #
+  # Type `mix help compile.app` for more information.
+  def application do
+    [mod: {ConfigurableBlinky, []},
+     applications: [:logger, :nerves_leds]]
+  end
+
+  def deps do
+    [{:nerves, "~> 0.3.0"},
+     {:nerves_leds, "~> 0.7.0"}]
+  end
+
+  def system(target) do
+    [{:"nerves_system_#{target}", ">= 0.0.0"}]
+  end
+
+  def aliases do
+    ["deps.precompile": ["nerves.precompile", "deps.precompile"],
+     "deps.loadpaths":  ["deps.loadpaths", "nerves.loadpaths"]]
+  end
+
+end

--- a/configurable_blinky/test/configurable_blinky_test.exs
+++ b/configurable_blinky/test/configurable_blinky_test.exs
@@ -1,0 +1,8 @@
+defmodule ConfigurableBlinkyTest do
+  use ExUnit.Case
+  doctest ConfigurableBlinky
+
+  test "the truth" do
+    assert 1 + 1 == 2
+  end
+end

--- a/configurable_blinky/test/test_helper.exs
+++ b/configurable_blinky/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start


### PR DESCRIPTION
Blink times can be configured.

This example builds on top of Blinky to demonstrate how nerves program can be dynamically configured, as one would with `sysctl` in traditional Unix systems or `/sys` on Linux.