### PR TITLE
Use triggers instead of infinite loops for blinky

### DIFF
--- a/blinky/lib/blinky.ex
+++ b/blinky/lib/blinky.ex
@@ -16,23 +16,26 @@ defmodule Blinky do
   def start(_type, _args) do
     led_list = Application.get_env(:blinky, :led_list)
     Logger.debug "list of leds to blink is #{inspect led_list}"
-    spawn fn -> blink_list_forever(led_list) end
+    Enum.each(led_list, &start_blink(&1))
     {:ok, self}
   end
 
-  # call blink_led on each led in the list sequence, repeating forever
-  defp blink_list_forever(led_list) do
-    Enum.each(led_list, &blink(&1))
-    blink_list_forever(led_list)
+  # Set led `led_key` to the state defined below. It is also possible
+  # to globally define states in `config/config.exs` by passing a list
+  # of states with the `:states` keyword.
+  #
+  # The first parameter must be an atom.
+  @spec start_blink(Keyword.T) :: true
+  defp start_blink(led_key) do
+    Logger.debug "blinking led #{inspect led_key}"
+    # led_key is a variable that contains an atom
+    Leds.set [{
+      led_key,
+      [
+        trigger: "timer",
+        delay_off: @off_duration,
+        delay_on: @on_duration * 10
+      ]
+    }]
   end
-
-  # given an led key, turn it on for 100ms then back off
-  defp blink(led_key) do
-    #Logger.debug "blinking led #{inspect led_key}"
-    Leds.set [{led_key, true}]
-    :timer.sleep @on_duration
-    Leds.set [{led_key, false}]
-    :timer.sleep @off_duration
-  end
-
 end

--- a/blinky/lib/blinky.ex
+++ b/blinky/lib/blinky.ex
@@ -16,26 +16,23 @@ defmodule Blinky do
   def start(_type, _args) do
     led_list = Application.get_env(:blinky, :led_list)
     Logger.debug "list of leds to blink is #{inspect led_list}"
-    Enum.each(led_list, &start_blink(&1))
+    spawn fn -> blink_list_forever(led_list) end
     {:ok, self}
   end
 
-  # Set led `led_key` to the state defined below. It is also possible
-  # to globally define states in `config/config.exs` by passing a list
-  # of states with the `:states` keyword.
-  #
-  # The first parameter must be an atom.
-  @spec start_blink(Keyword.T) :: true
-  defp start_blink(led_key) do
-    Logger.debug "blinking led #{inspect led_key}"
-    # led_key is a variable that contains an atom
-    Leds.set [{
-      led_key,
-      [
-        trigger: "timer",
-        delay_off: @off_duration,
-        delay_on: @on_duration * 10
-      ]
-    }]
+  # call blink_led on each led in the list sequence, repeating forever
+  defp blink_list_forever(led_list) do
+    Enum.each(led_list, &blink(&1))
+    blink_list_forever(led_list)
   end
+
+  # given an led key, turn it on for 100ms then back off
+  defp blink(led_key) do
+    #Logger.debug "blinking led #{inspect led_key}"
+    Leds.set [{led_key, true}]
+    :timer.sleep @on_duration
+    Leds.set [{led_key, false}]
+    :timer.sleep @off_duration
+  end
+
 end

--- a/hello_leds/CHANGELOG.md
+++ b/hello_leds/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.3.0
+
+* Move to `nerves_system_*` 0.6
+
+## 0.2.0
+
+* Changes for `nerves_leds` vs `nerves_io_led`

--- a/hello_leds/README.md
+++ b/hello_leds/README.md
@@ -1,0 +1,8 @@
+# `hello_leds`
+
+Functionaly similar to `blinky`, using the Linux leds class instead of manually asserting the GPIO line.
+
+- Boots to Elixir shell and blinks LEDs forever in background
+- Uses `Nerves.LED to manage named LEDs
+- Custom per-target configuration via `config/#{target}.exs`
+- Builds off-target with debug output via `Logger`

--- a/hello_leds/config/alix.exs
+++ b/hello_leds/config/alix.exs
@@ -1,0 +1,10 @@
+# configuration for PC Engines Alix 2d/3d series (target alix)
+use Mix.Config
+
+config :hello_leds, led_list: [ :led1, :led2, :led3 ]
+
+config :nerves_leds, names: [
+  led1: "alix:1",
+  led2: "alix:2",
+  led3: "alix:3"
+]

--- a/hello_leds/config/bbb.exs
+++ b/hello_leds/config/bbb.exs
@@ -1,0 +1,11 @@
+# configuration for Beaglebone Black (target bbb)
+use Mix.Config
+
+config :hello_leds, led_list: [ :led0, :led1, :led2, :led3 ]
+
+config :nerves_leds, names: [
+  led0: "beaglebone:green:usr0",
+  led1: "beaglebone:green:usr1",
+  led2: "beaglebone:green:usr2",
+  led3: "beaglebone:green:usr3"
+]

--- a/hello_leds/config/config.exs
+++ b/hello_leds/config/config.exs
@@ -1,0 +1,9 @@
+use Mix.Config
+
+# this default configuration is appropriate for the raspberry pi
+# it is overridden by custom target configuration brought below
+
+config :hello_leds, led_list: [ :red, :green ]
+config :nerves_leds, names: [ red: "led0", green: "led1" ]
+
+import_config "#{Mix.Project.config[:target]}.exs"

--- a/hello_leds/config/ev3.exs
+++ b/hello_leds/config/ev3.exs
@@ -1,0 +1,11 @@
+# Configuration for the Lego Mindstorms EV3 brick (target ev3)
+use Mix.Config
+
+config :hello_leds, led_list: [ :led0, :led1, :led2, :led3 ]
+
+config :nerves_leds, names: [
+  led0: "ev3:left:green:ev3dev",
+  led1: "ev3:right:green:ev3dev",
+  led2: "ev3:left:red:ev3dev",
+  led3: "ev3:right:red:ev3dev"
+]

--- a/hello_leds/config/rpi.exs
+++ b/hello_leds/config/rpi.exs
@@ -1,0 +1,4 @@
+# Configuration for the Raspberry Pi A+ / B+ / B / Zero (target rpi)
+use Mix.Config
+
+config :nerves_leds, names: [ red: "led0", green: "led1" ]

--- a/hello_leds/config/rpi2.exs
+++ b/hello_leds/config/rpi2.exs
@@ -1,0 +1,4 @@
+# Configuration for the Raspberry Pi 2 Model B (target rpi2)
+use Mix.Config
+
+config :nerves_leds, names: [ red: "led0", green: "led1" ]

--- a/hello_leds/config/rpi3.exs
+++ b/hello_leds/config/rpi3.exs
@@ -1,0 +1,5 @@
+# Configuration for the Raspberry Pi 3 (target rpi3)
+use Mix.Config
+
+config :hello_leds, led_list: [ :green ]
+config :nerves_leds, names: [ green: "led0" ]

--- a/hello_leds/lib/hello_leds.ex
+++ b/hello_leds/lib/hello_leds.ex
@@ -1,0 +1,41 @@
+defmodule HelloLeds do
+
+  @moduledoc """
+  Simple example to blink a list of LEDs forever.
+
+  The list of LEDs is platform-dependent, and defined in the config
+  directory (see config.exs).   See README.md for build instructions.
+  """
+
+  @on_duration  200 # ms
+  @off_duration 200 # ms
+
+  alias Nerves.Leds
+  require Logger
+
+  def start(_type, _args) do
+    led_list = Application.get_env(:hello_leds, :led_list)
+    Logger.debug "list of leds to blink is #{inspect led_list}"
+    Enum.each(led_list, &start_blink(&1))
+    {:ok, self}
+  end
+
+  # Set led `led_key` to the state defined below. It is also possible
+  # to globally define states in `config/config.exs` by passing a list
+  # of states with the `:states` keyword.
+  #
+  # The first parameter must be an atom.
+  @spec start_blink(Keyword.T) :: true
+  defp start_blink(led_key) do
+    Logger.debug "blinking led #{inspect led_key}"
+    # led_key is a variable that contains an atom
+    Leds.set [{
+      led_key,
+      [
+        trigger: "timer",
+        delay_off: @off_duration,
+        delay_on: @on_duration
+      ]
+    }]
+  end
+end

--- a/hello_leds/mix.exs
+++ b/hello_leds/mix.exs
@@ -1,0 +1,41 @@
+defmodule HelloLeds.Mixfile do
+  use Mix.Project
+
+  @target System.get_env("NERVES_TARGET") || "rpi"
+
+  def project do
+    [app: :hello_leds,
+     version: "0.2.0",
+     elixir: "~> 1.3",
+     archives: [nerves_bootstrap: "~> 0.1.3"],
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     target: @target,
+     deps_path: "deps/#{@target}",
+     build_path: "_build/#{@target}",
+     aliases: aliases(),
+     deps: deps() ++ system(@target)]
+  end
+
+  def application do
+    [mod: {HelloLeds, []},
+     applications: [:logger, :nerves_leds]]
+  end
+
+  defp deps do
+    [{:nerves, "~> 0.3.0"},
+     {:nerves_leds, "~> 0.7.0"}]
+  end
+
+  def system(target) do
+    [
+     {:"nerves_system_#{target}", "~> 0.6"}
+    ]
+  end
+
+  def aliases do
+    ["deps.precompile": ["nerves.precompile", "deps.precompile"],
+     "deps.loadpaths":  ["deps.loadpaths",    "nerves.loadpaths"]]
+  end
+
+end

--- a/hello_leds/test/hello_leds_test.exs
+++ b/hello_leds/test/hello_leds_test.exs
@@ -1,0 +1,8 @@
+defmodule HelloLedsTest do
+  use ExUnit.Case
+  doctest HelloLeds
+
+  test "the truth" do
+    assert 1 + 1 == 2
+  end
+end

--- a/hello_leds/test/test_helper.exs
+++ b/hello_leds/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
As discussed in #29, here is a new version of blinky that uses `trigger` instead of manually setting the led on and off again.