### PR TITLE
Add the modules for the typical USB WiFi dongles 

### DIFF
--- a/hello_wifi/mix.exs
+++ b/hello_wifi/mix.exs
@@ -70,9 +70,9 @@ defmodule HelloWifi.Mixfile do
      "deps.loadpaths":  ["deps.loadpaths", "nerves.loadpaths"]]
   end
 
-  def kernel_modules("rpi3") do
-    ["brcmfmac"]
-  end
+  def kernel_modules("rpi3"), do: ["brcmfmac"]
+  def kernel_modules("rpi2"), do: ["8192cu"]
+  def kernel_modules("rpi"), do: ["8192cu"]
   def kernel_modules(_), do: []
 
   def aliases do


### PR DESCRIPTION
On a RPI and RPI2 board, usually USB WiFi dongles are used. Here the example is extended to show which module is used for the popular 8192 broadcom chipset (contained in many starter kits). 
