### PR TITLE
Use 0.13.0 for rpi0 to support builtin WiFi with the brcmfmac driver

### DIFF
--- a/hello_wifi/mix.exs
+++ b/hello_wifi/mix.exs
@@ -65,7 +65,7 @@ defmodule HelloWifi.Mixfile do
   end
 
   # Specify the version of the System to use for each target
-  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.12.0", runtime: false}
+  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.13.0", runtime: false}
   def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.12.0", runtime: false}
   def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.12.1", runtime: false}
   def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.12.0", runtime: false}
@@ -85,6 +85,7 @@ defmodule HelloWifi.Mixfile do
      "deps.loadpaths":  ["deps.loadpaths", "nerves.loadpaths"]]
   end
 
+  def kernel_modules("rpi0"), do: ["brcmfmac"]
   def kernel_modules("rpi3"), do: ["brcmfmac"]
   def kernel_modules("rpi2"), do: ["8192cu"]
   def kernel_modules("rpi"), do: ["8192cu"]


### PR DESCRIPTION
Use the newer 0.13.0 system for rpi0w which supports the build-in WiFi if the required driver is loaded as a module. 

This is the change mentioned in https://github.com/nerves-project/nerves_system_rpi0/pull/7