### PR TITLE
Update system deps and nerves deps

### DIFF
--- a/blinky/config/rpi0.exs
+++ b/blinky/config/rpi0.exs
@@ -1,0 +1,5 @@
+# Configuration for the Raspberry Pi Zero (target rpi0)
+use Mix.Config
+
+config :blinky, led_list: [ :green ]
+config :nerves_leds, names: [ green: "led0" ]

--- a/blinky/mix.exs
+++ b/blinky/mix.exs
@@ -14,7 +14,7 @@ defmodule Blinky.Mixfile do
      version: "0.3.0",
      elixir: "~> 1.4.0",
      target: @target,
-     archives: [nerves_bootstrap: "~> 0.3.0"],
+     archives: [nerves_bootstrap: "~> 0.5"],
      deps_path: "deps/#{@target}",
      build_path: "_build/#{@target}",
      build_embedded: Mix.env == :prod,
@@ -53,7 +53,7 @@ defmodule Blinky.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   def deps do
-    [{:nerves, "~> 0.5.1", runtime: false}] ++
+    [{:nerves, "~> 0.6.1", runtime: false}] ++
     deps(@target)
   end
 
@@ -67,16 +67,16 @@ defmodule Blinky.Mixfile do
   end
 
   # Specify the version of the System to use for each target
-  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.12.0", runtime: false}
-  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.12.0", runtime: false}
-  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.12.1", runtime: false}
-  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.12.0", runtime: false}
-  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.12.0", runtime: false}
+  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.15.0", runtime: false}
+  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.13.0", runtime: false}
+  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.13.0", runtime: false}
+  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.13.0", runtime: false}
+  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.13.0", runtime: false}
   def system("alix"), do:       {:nerves_system_alix,       "~> 0.7.0",  runtime: false}
   def system("ag150"), do:      {:nerves_system_ag150,      "~> 0.7.0",  runtime: false}
   def system("galileo"), do:    {:nerves_system_galileo,    "~> 0.7.0",  runtime: false}
   def system("ev3"), do:        {:nerves_system_ev3,        "~> 0.11.0", runtime: false}
-  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.11.0", runtime: false}
+  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.12.0", runtime: false}
   def system("qemu_arm"), do:   {:nerves_system_qemu_arm,   "~> 0.11.0", runtime: false}
   def system(target), do:       Mix.raise "Unknown MIX_TARGET: #{target}"
 

--- a/hello_gpio/mix.exs
+++ b/hello_gpio/mix.exs
@@ -14,7 +14,7 @@ defmodule HelloGpio.Mixfile do
      version: "0.1.0",
      elixir: "~> 1.4.0",
      target: @target,
-     archives: [nerves_bootstrap: "~> 0.3.0"],
+     archives: [nerves_bootstrap: "~> 0.5"],
      deps_path: "deps/#{@target}",
      build_path: "_build/#{@target}",
      build_embedded: Mix.env == :prod,
@@ -50,7 +50,7 @@ defmodule HelloGpio.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   def deps do
-    [{:nerves, "~> 0.5.1", runtime: false}] ++
+    [{:nerves, "~> 0.6.1", runtime: false}] ++
     deps(@target)
   end
 
@@ -64,16 +64,16 @@ defmodule HelloGpio.Mixfile do
   end
 
   # Specify the version of the System to use for each target
-  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.12.0", runtime: false}
-  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.12.0", runtime: false}
-  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.12.1", runtime: false}
-  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.12.0", runtime: false}
-  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.12.0", runtime: false}
+  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.15.0", runtime: false}
+  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.13.0", runtime: false}
+  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.13.0", runtime: false}
+  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.13.0", runtime: false}
+  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.13.0", runtime: false}
   def system("alix"), do:       {:nerves_system_alix,       "~> 0.7.0",  runtime: false}
   def system("ag150"), do:      {:nerves_system_ag150,      "~> 0.7.0",  runtime: false}
   def system("galileo"), do:    {:nerves_system_galileo,    "~> 0.7.0",  runtime: false}
   def system("ev3"), do:        {:nerves_system_ev3,        "~> 0.11.0", runtime: false}
-  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.11.0", runtime: false}
+  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.12.0", runtime: false}
   def system("qemu_arm"), do:   {:nerves_system_qemu_arm,   "~> 0.11.0", runtime: false}
   def system(target), do:       Mix.raise "Unknown MIX_TARGET: #{target}"
 

--- a/hello_gpio_input/mix.exs
+++ b/hello_gpio_input/mix.exs
@@ -14,7 +14,7 @@ defmodule HelloGpioInput.Mixfile do
      version: "0.1.0",
      elixir: "~> 1.4.0",
      target: @target,
-     archives: [nerves_bootstrap: "~> 0.3.0"],
+     archives: [nerves_bootstrap: "~> 0.5"],
      deps_path: "deps/#{@target}",
      build_path: "_build/#{@target}",
      build_embedded: Mix.env == :prod,
@@ -50,7 +50,7 @@ defmodule HelloGpioInput.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   def deps do
-    [{:nerves, "~> 0.5.1", runtime: false}] ++
+    [{:nerves, "~> 0.6.1", runtime: false}] ++
     deps(@target)
   end
 
@@ -64,16 +64,16 @@ defmodule HelloGpioInput.Mixfile do
   end
 
   # Specify the version of the System to use for each target
-  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.12.0", runtime: false}
-  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.12.0", runtime: false}
-  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.12.1", runtime: false}
-  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.12.0", runtime: false}
-  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.12.0", runtime: false}
+  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.15.0", runtime: false}
+  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.13.0", runtime: false}
+  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.13.0", runtime: false}
+  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.13.0", runtime: false}
+  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.13.0", runtime: false}
   def system("alix"), do:       {:nerves_system_alix,       "~> 0.7.0",  runtime: false}
   def system("ag150"), do:      {:nerves_system_ag150,      "~> 0.7.0",  runtime: false}
   def system("galileo"), do:    {:nerves_system_galileo,    "~> 0.7.0",  runtime: false}
   def system("ev3"), do:        {:nerves_system_ev3,        "~> 0.11.0", runtime: false}
-  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.11.0", runtime: false}
+  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.12.0", runtime: false}
   def system("qemu_arm"), do:   {:nerves_system_qemu_arm,   "~> 0.11.0", runtime: false}
   def system(target), do:       Mix.raise "Unknown MIX_TARGET: #{target}"
 

--- a/hello_leds/config/rpi0.exs
+++ b/hello_leds/config/rpi0.exs
@@ -1,0 +1,5 @@
+# Configuration for the Raspberry Pi Zero (target rpi0)
+use Mix.Config
+
+config :hello_leds, led_list: [ :green ]
+config :nerves_leds, names: [ green: "led0" ]

--- a/hello_leds/mix.exs
+++ b/hello_leds/mix.exs
@@ -14,7 +14,7 @@ defmodule HelloLeds.Mixfile do
      version: "0.1.0",
      elixir: "~> 1.4.0",
      target: @target,
-     archives: [nerves_bootstrap: "~> 0.3.0"],
+     archives: [nerves_bootstrap: "~> 0.5"],
      deps_path: "deps/#{@target}",
      build_path: "_build/#{@target}",
      build_embedded: Mix.env == :prod,
@@ -50,7 +50,7 @@ defmodule HelloLeds.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   def deps do
-    [{:nerves, "~> 0.5.1", runtime: false}] ++
+    [{:nerves, "~> 0.6.1", runtime: false}] ++
     deps(@target)
   end
 
@@ -64,16 +64,16 @@ defmodule HelloLeds.Mixfile do
   end
 
   # Specify the version of the System to use for each target
-  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.12.0", runtime: false}
-  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.12.0", runtime: false}
-  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.12.1", runtime: false}
-  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.12.0", runtime: false}
-  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.12.0", runtime: false}
+  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.15.0", runtime: false}
+  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.13.0", runtime: false}
+  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.13.0", runtime: false}
+  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.13.0", runtime: false}
+  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.13.0", runtime: false}
   def system("alix"), do:       {:nerves_system_alix,       "~> 0.7.0",  runtime: false}
   def system("ag150"), do:      {:nerves_system_ag150,      "~> 0.7.0",  runtime: false}
   def system("galileo"), do:    {:nerves_system_galileo,    "~> 0.7.0",  runtime: false}
   def system("ev3"), do:        {:nerves_system_ev3,        "~> 0.11.0", runtime: false}
-  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.11.0", runtime: false}
+  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.12.0", runtime: false}
   def system("qemu_arm"), do:   {:nerves_system_qemu_arm,   "~> 0.11.0", runtime: false}
   def system(target), do:       Mix.raise "Unknown MIX_TARGET: #{target}"
 

--- a/hello_network/mix.exs
+++ b/hello_network/mix.exs
@@ -14,7 +14,7 @@ defmodule HelloNetwork.Mixfile do
      version: "0.2.0",
      elixir: "~> 1.4.0",
      target: @target,
-     archives: [nerves_bootstrap: "~> 0.3.0"],
+     archives: [nerves_bootstrap: "~> 0.5"],
      deps_path: "deps/#{@target}",
      build_path: "_build/#{@target}",
      build_embedded: Mix.env == :prod,
@@ -50,7 +50,7 @@ defmodule HelloNetwork.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   def deps do
-    [{:nerves, "~> 0.5.1", runtime: false}] ++
+    [{:nerves, "~> 0.6.1", runtime: false}] ++
     deps(@target)
   end
 
@@ -64,16 +64,16 @@ defmodule HelloNetwork.Mixfile do
   end
 
   # Specify the version of the System to use for each target
-  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.12.0", runtime: false}
-  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.12.0", runtime: false}
-  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.12.1", runtime: false}
-  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.12.0", runtime: false}
-  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.12.0", runtime: false}
+  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.15.0", runtime: false}
+  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.13.0", runtime: false}
+  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.13.0", runtime: false}
+  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.13.0", runtime: false}
+  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.13.0", runtime: false}
   def system("alix"), do:       {:nerves_system_alix,       "~> 0.7.0",  runtime: false}
   def system("ag150"), do:      {:nerves_system_ag150,      "~> 0.7.0",  runtime: false}
   def system("galileo"), do:    {:nerves_system_galileo,    "~> 0.7.0",  runtime: false}
   def system("ev3"), do:        {:nerves_system_ev3,        "~> 0.11.0", runtime: false}
-  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.11.0", runtime: false}
+  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.12.0", runtime: false}
   def system("qemu_arm"), do:   {:nerves_system_qemu_arm,   "~> 0.11.0", runtime: false}
   def system(target), do:       Mix.raise "Unknown MIX_TARGET: #{target}"
 

--- a/hello_phoenix/apps/fw/mix.exs
+++ b/hello_phoenix/apps/fw/mix.exs
@@ -14,7 +14,7 @@ defmodule Fw.Mixfile do
      version: "0.1.0",
      elixir: "~> 1.4.0",
      target: @target,
-     archives: [nerves_bootstrap: "~> 0.3.0"],
+     archives: [nerves_bootstrap: "~> 0.5"],
      deps_path: "../../deps/#{@target}",
      build_path: "../../_build/#{@target}",
      lockfile: "../../mix.lock",
@@ -51,7 +51,7 @@ defmodule Fw.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   def deps do
-    [{:nerves, "~> 0.5.1", runtime: false}] ++
+    [{:nerves, "~> 0.6.1", runtime: false}] ++
     deps(@target)
   end
 
@@ -66,16 +66,16 @@ defmodule Fw.Mixfile do
   end
 
   # Specify the version of the System to use for each target
-  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.12.0", runtime: false}
-  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.12.0", runtime: false}
-  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.12.1", runtime: false}
-  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.12.0", runtime: false}
-  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.12.0", runtime: false}
+  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.15.0", runtime: false}
+  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.13.0", runtime: false}
+  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.13.0", runtime: false}
+  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.13.0", runtime: false}
+  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.13.0", runtime: false}
   def system("alix"), do:       {:nerves_system_alix,       "~> 0.7.0",  runtime: false}
   def system("ag150"), do:      {:nerves_system_ag150,      "~> 0.7.0",  runtime: false}
   def system("galileo"), do:    {:nerves_system_galileo,    "~> 0.7.0",  runtime: false}
   def system("ev3"), do:        {:nerves_system_ev3,        "~> 0.11.0", runtime: false}
-  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.11.0", runtime: false}
+  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.12.0", runtime: false}
   def system("qemu_arm"), do:   {:nerves_system_qemu_arm,   "~> 0.11.0", runtime: false}
   def system(target), do:       Mix.raise "Unknown MIX_TARGET: #{target}"
 

--- a/hello_wifi/mix.exs
+++ b/hello_wifi/mix.exs
@@ -14,7 +14,7 @@ defmodule HelloWifi.Mixfile do
      version: "0.1.0",
      elixir: "~> 1.4.0",
      target: @target,
-     archives: [nerves_bootstrap: "~> 0.3.0"],
+     archives: [nerves_bootstrap: "~> 0.5"],
      kernel_modules: kernel_modules(@target),
      deps_path: "deps/#{@target}",
      build_path: "_build/#{@target}",
@@ -51,7 +51,7 @@ defmodule HelloWifi.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   def deps do
-    [{:nerves, "~> 0.5.1", runtime: false}] ++
+    [{:nerves, "~> 0.6.1", runtime: false}] ++
     deps(@target)
   end
 
@@ -65,16 +65,16 @@ defmodule HelloWifi.Mixfile do
   end
 
   # Specify the version of the System to use for each target
-  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.13.0", runtime: false}
-  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.12.0", runtime: false}
-  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.12.1", runtime: false}
-  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.12.0", runtime: false}
-  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.12.0", runtime: false}
+  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.15.0", runtime: false}
+  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.13.0", runtime: false}
+  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.13.0", runtime: false}
+  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.13.0", runtime: false}
+  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.13.0", runtime: false}
   def system("alix"), do:       {:nerves_system_alix,       "~> 0.7.0",  runtime: false}
   def system("ag150"), do:      {:nerves_system_ag150,      "~> 0.7.0",  runtime: false}
   def system("galileo"), do:    {:nerves_system_galileo,    "~> 0.7.0",  runtime: false}
   def system("ev3"), do:        {:nerves_system_ev3,        "~> 0.11.0", runtime: false}
-  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.11.0", runtime: false}
+  def system("linkit"), do:     {:nerves_system_linkit,     "~> 0.12.0", runtime: false}
   def system("qemu_arm"), do:   {:nerves_system_qemu_arm,   "~> 0.11.0", runtime: false}
   def system(target), do:       Mix.raise "Unknown MIX_TARGET: #{target}"
 

--- a/neopixel/mix.exs
+++ b/neopixel/mix.exs
@@ -14,7 +14,7 @@ defmodule Neopixel.Mixfile do
      version: "0.1.0",
      elixir: "~> 1.4.0",
      target: @target,
-     archives: [nerves_bootstrap: "~> 0.3.0"],
+     archives: [nerves_bootstrap: "~> 0.5"],
      deps_path: "deps/#{@target}",
      build_path: "_build/#{@target}",
      build_embedded: Mix.env == :prod,
@@ -50,7 +50,7 @@ defmodule Neopixel.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   def deps do
-    [{:nerves, "~> 0.5.1", runtime: false}] ++
+    [{:nerves, "~> 0.6.1", runtime: false}] ++
     deps(@target)
   end
 
@@ -64,10 +64,10 @@ defmodule Neopixel.Mixfile do
   end
 
   # Specify the version of the System to use for each target
-  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.12.0", runtime: false}
-  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.12.0", runtime: false}
-  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.12.1", runtime: false}
-  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.12.0", runtime: false}
+  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.15.0", runtime: false}
+  def system("rpi"), do:        {:nerves_system_rpi,        "~> 0.13.0", runtime: false}
+  def system("rpi2"), do:       {:nerves_system_rpi2,       "~> 0.13.0", runtime: false}
+  def system("rpi3"), do:       {:nerves_system_rpi3,       "~> 0.13.0", runtime: false}
   def system("qemu_arm"), do:   {:nerves_system_qemu_arm,   "~> 0.11.0", runtime: false}
   def system("bbb"), do:        Mix.raise "Sorry, this example only works on Raspberry Pi"
   def system("alix"), do:       Mix.raise "Sorry, this example only works on Raspberry Pi"


### PR DESCRIPTION
This updates things to the latest released versions, which doesn't include OTP 20 yet, but gets us where the examples should work with OTP 19 and the latest `nerves` and `nerves_boostrap`.