### PR TITLE
Bump nerves runtime version to 0.4.2 in hello_phoenix

### DIFF
--- a/hello_phoenix/apps/fw/mix.exs
+++ b/hello_phoenix/apps/fw/mix.exs
@@ -59,7 +59,7 @@ defmodule Fw.Mixfile do
   def deps("host"), do: []
   def deps(target) do
     [ system(target),
-      {:nerves_runtime, "~> 0.1.0"},
+      {:nerves_runtime, "~> 0.4.2"},
       {:nerves_networking, "~> 0.6.0"},
       {:ui, in_umbrella: true},
     ]


### PR DESCRIPTION
When compiling on macOS Sierra 10.12.5, `v 0.1.0` errors when compiling:
```
==> nerves_runtime
Makefile:15: *** Nerves runtime only works on Linux. Crosscompiling is possible if $CROSSCOMPILE is set..  Stop.
could not compile dependency :nerves_runtime, "mix compile" failed. You can recompile this dependency with "mix deps.compile nerves_runtime", update it with "mix deps.update nerves_runtime" or clean it with "mix deps.clean nerves_runtime"
** (Mix) Could not compile with "make" (exit status: 2).
Depending on your OS, make sure to follow these instructions:

  * Mac OS X: You need to have gcc and make installed. Try running the
    commands "gcc --version" and / or "make --version". If these programs
    are not installed, you will be prompted to install them.

  * Linux: You need to have gcc and make installed. If you are using
    Ubuntu or any other Debian-based system, install the packages
    "build-essential". Also install "erlang-dev" package if not
    included in your Erlang/OTP version. If you're on Fedora, run
    "dnf group install 'Development Tools'".
```

Bumping the versions makes everything run clean.